### PR TITLE
Remove broken provide rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,6 @@
         "eloquent/composer-config-reader": "~2.0",
         "docker-php/docker-php": "~1.24"
     },
-    "provide": {
-        "ext-mbstring": "*"
-    },
     "suggest": {
         "php-school/cli-menu": "For init menu"
     }


### PR DESCRIPTION
This package does not provide a polyfill for the ext-mbstring at all. Lying about it for a package that is available on Packagist is a bad idea as it could lead to broken dependency resolution if a project depends on both this package and a package needing mbstring.